### PR TITLE
Allow correct item to get icon updates for both kde and gtk implementation

### DIFF
--- a/swaybar/tray/sni.c
+++ b/swaybar/tray/sni.c
@@ -334,7 +334,7 @@ int sni_obj_name_cmp(const void *_item, const void *_obj_name) {
 	const struct StatusNotifierItem *item = _item;
 	const struct ObjName *obj_name = _obj_name;
 
-	if (strcmp(item->name, obj_name->name) == 0 &&
+	if (strcmp(item->unique_name, obj_name->name) == 0 &&
 			strcmp(item->object_path, obj_name->obj_path) == 0) {
 		return 0;
 	}


### PR DESCRIPTION
https://github.com/swaywm/sway/pull/1431/commits/3f956f919a8041ebd3d06214be4b7f146d290cd9 fixed correct icon updates for appindicator, but broke them for ksni, so fix this to support both
For https://github.com/swaywm/sway/pull/1431